### PR TITLE
feat: add Windows read-only Vault adapter

### DIFF
--- a/.github/workflows/windows-readonly-adapter.yml
+++ b/.github/workflows/windows-readonly-adapter.yml
@@ -1,0 +1,55 @@
+name: Windows read-only adapter
+
+on:
+  push:
+    paths:
+      - 'yichen-wechat-windows-readonly/**'
+      - '.github/workflows/windows-readonly-adapter.yml'
+  pull_request:
+    paths:
+      - 'yichen-wechat-windows-readonly/**'
+      - '.github/workflows/windows-readonly-adapter.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-readonly-adapter-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Build synthetic fixture
+        shell: pwsh
+        run: |
+          $fixture = Join-Path $env:RUNNER_TEMP 'windows-readonly-synthetic-vault'
+          python yichen-wechat-windows-readonly/tests/fixtures/build_synthetic_vault.py --output $fixture
+
+      - name: Run unit tests
+        shell: pwsh
+        env:
+          PYTHONDONTWRITEBYTECODE: '1'
+        run: python -m unittest discover -s yichen-wechat-windows-readonly/tests -v
+
+      - name: Check pull request whitespace
+        shell: pwsh
+        run: |
+          $base = '${{ github.event.pull_request.base.sha }}'
+          if (-not $base) {
+            $base = git merge-base HEAD origin/main
+          }
+          git diff --check "$base..HEAD"

--- a/docs/superpowers/specs/2026-08-18-windows-wechat-vault-design.md
+++ b/docs/superpowers/specs/2026-08-18-windows-wechat-vault-design.md
@@ -1,0 +1,53 @@
+# Windows WeChat Vault Skill Design
+
+## Goal
+
+Publish the supplied Windows WeChat local-vault skill in `mcncarl/yichen-skills` without altering the maintained macOS vault or exposing personal data.
+
+## Scope
+
+- Add a new, self-contained `yichen-wechat-windows-vault/` skill directory from the supplied v0.3.0 archive.
+- Preserve the archive's Windows-only implementation, privacy rules, compatibility reference, MCP configuration, and self-test.
+- Add concise English and Chinese entries to the repository indexes so users can discover the Windows skill and its OS boundary.
+- Add the new directory to the README project trees and the documented stable directory-name lists.
+
+## Deliberate boundaries
+
+- Do not merge this implementation into `yichen-wechat-local-vault`; that directory is macOS-only and uses a different database format, key extraction flow, filesystem layout, and dependencies.
+- Do not change existing macOS behavior or installation guidance.
+- Do not include keys, live databases, decrypted exports, media caches, credentials, user paths, or chat content.
+- Do not claim support for an unlisted WeChat build; the bundled compatibility checks remain authoritative.
+
+## Layout
+
+```text
+yichen-wechat-windows-vault/
+├─ SKILL.md
+├─ README.md
+├─ agents/openai.yaml
+├─ references/
+│  ├─ compatibility.md
+│  └─ profile-fixtures.json
+└─ scripts/
+   ├─ setup.ps1
+   ├─ uninstall.ps1
+   ├─ capture_keys.py
+   ├─ decrypt_databases.py
+   ├─ refresh_vault.py
+   ├─ diagnose.py
+   ├─ self_test.py
+   ├─ vault_cli.py
+   ├─ vault_common.py
+   ├─ wechat_media.py
+   ├─ decode_silk.cjs
+   ├─ gateway_query.py
+   ├─ mcp_server.py
+   └─ requirements.txt
+```
+
+## Validation
+
+1. Check that the imported file set matches the archive and that no tracked file matches repository secret/database/media exclusions.
+2. Run Python syntax compilation for the bundled Windows scripts on the current host; this checks syntax only and does not attach to WeChat or read local user data.
+3. Run the archive's profile-fixture validation in an isolated import context; full `self_test.py` is intentionally not expected to pass on macOS because it validates Windows-only dependencies and paths.
+4. Review the final diff and README links before committing and opening the PR.

--- a/yichen-wechat-windows-readonly/PROVENANCE.md
+++ b/yichen-wechat-windows-readonly/PROVENANCE.md
@@ -1,0 +1,24 @@
+# Provenance
+
+## Contribution boundary
+
+- Clean upstream baseline: `ca8281900412e2256e5a45f4d6995fa340af5a71` from `mcncarl/yichen-skills`.
+- Authorization: the repository author approved a new, clean, reduced-scope Windows contribution, as recorded in the contributor's private execution handoff.
+- Functional and documentation reference: the clean-baseline `yichen-wechat-local-vault` documentation and its read-only query entry point only.
+- Excluded sources: every earlier Windows implementation and audit bundle, and every third-party Windows WeChat extraction/decryption implementation.
+
+No excluded source was opened, copied, translated, adapted, or used to produce these files.
+
+## File-by-file record
+
+| File | Origin |
+| --- | --- |
+| `README.md` | New text written for this contribution from the approved scope and safety requirements. |
+| `SKILL.md` | New minimal skill instructions written for this contribution from the approved scope and safety requirements. |
+| `PROVENANCE.md` | New audit record written for this contribution. |
+| `THIRD_PARTY.md` | New dependency and license record written for this contribution. |
+| `tests/README.md` | New test plan derived from the approved acceptance gates. |
+| `tests/fixtures/README.md` | New synthetic-fixture policy written for this contribution. |
+| `tests/fixtures/build_synthetic_vault.py` | New Python standard-library fixture generator. Table and command semantics are limited to the clean-baseline Mac skill's read-only query interface. All records are fictional. |
+
+Every file added in later commits must be appended to this table before pull request creation.

--- a/yichen-wechat-windows-readonly/PROVENANCE.md
+++ b/yichen-wechat-windows-readonly/PROVENANCE.md
@@ -20,5 +20,8 @@ No excluded source was opened, copied, translated, adapted, or used to produce t
 | `tests/README.md` | New test plan derived from the approved acceptance gates. |
 | `tests/fixtures/README.md` | New synthetic-fixture policy written for this contribution. |
 | `tests/fixtures/build_synthetic_vault.py` | New Python standard-library fixture generator. Table and command semantics are limited to the clean-baseline Mac skill's read-only query interface. All records are fictional. |
+| `scripts/windows_readonly_adapter.py` | New Python standard-library implementation written for this contribution. Command and table semantics use only the clean-baseline Mac skill's read-only query interface; Windows path, consent, snapshot, redaction, and fail-closed controls are new. |
+| `tests/test_windows_readonly_adapter.py` | New unit and integration tests written for this contribution using only generated fictional data and temporary directories. |
+| `.github/workflows/windows-readonly-adapter.yml` | New Windows CI workflow. Structure and pinned official action versions follow the clean-baseline `.github/workflows/x-article-draft-uploader.yml`. |
 
-Every file added in later commits must be appended to this table before pull request creation.
+No earlier Windows implementation, binary, package, fork, mirror, or audit bundle was used.

--- a/yichen-wechat-windows-readonly/PROVENANCE.md
+++ b/yichen-wechat-windows-readonly/PROVENANCE.md
@@ -5,9 +5,9 @@
 - Clean upstream baseline: `ca8281900412e2256e5a45f4d6995fa340af5a71` from `mcncarl/yichen-skills`.
 - Authorization: the repository author approved a new, clean, reduced-scope Windows contribution, as recorded in the contributor's private execution handoff.
 - Functional and documentation reference: the clean-baseline `yichen-wechat-local-vault` documentation and its read-only query entry point only.
-- Excluded sources: every earlier Windows implementation and audit bundle, and every third-party Windows WeChat extraction/decryption implementation.
+- Excluded implementation sources: every earlier Windows implementation and audit bundle, and every third-party Windows WeChat extraction/decryption implementation.
 
-No excluded source was opened, copied, translated, adapted, or used to produce these files.
+Earlier private Windows archives were inspected separately only to audit prohibited names, dependencies, and direct file lineage. That audit happened after this contribution was written. No archived implementation was copied, translated, adapted, or used as a design or code source. Third-party Windows WeChat extraction/decryption source was not inspected.
 
 ## File-by-file record
 
@@ -24,4 +24,4 @@ No excluded source was opened, copied, translated, adapted, or used to produce t
 | `tests/test_windows_readonly_adapter.py` | New unit and integration tests written for this contribution using only generated fictional data and temporary directories. |
 | `.github/workflows/windows-readonly-adapter.yml` | New Windows CI workflow. Structure and pinned official action versions follow the clean-baseline `.github/workflows/x-article-draft-uploader.yml`. |
 
-No earlier Windows implementation, binary, package, fork, mirror, or audit bundle was used.
+No earlier Windows implementation, binary, package, fork, mirror, or audit bundle was used to produce the contribution.

--- a/yichen-wechat-windows-readonly/README.md
+++ b/yichen-wechat-windows-readonly/README.md
@@ -1,38 +1,74 @@
 # Windows Read-Only Adapter
 
-This skill is a narrowly scoped adapter for inspecting and querying an explicitly selected, already-decrypted local WeChat Vault copy on Windows.
+Windows adapter for explicit, read-only queries against an already-decrypted local WeChat Vault copy.
 
-## Scope
+It is deliberately narrower than a general Windows WeChat parser. The user must select the Vault root, the supported layout must already contain readable SQLite files, and every content-bearing command requires consent on that invocation.
 
-The adapter will provide:
+## Supported Vault layout
 
-- metadata-only diagnostics for a Vault root supplied with `--vault-root`;
-- read-only session and contact queries;
-- read-only text history search and message statistics;
-- fail-closed handling for invalid paths, corrupt SQLite files, WAL snapshots, concurrent changes, and ambiguous contacts.
+```text
+<vault-root>/
+  contact/contact.db
+  session/session.db
+  message/message_*.db
+```
 
-The Vault root is never guessed. The adapter does not scan Documents, Desktop, OneDrive, or any other common user directory.
+The table semantics follow the clean-baseline `yichen-wechat-local-vault` read-only query interface. Schema mismatches fail closed with a redacted error.
+
+## Requirements and installation
+
+- Windows
+- Python 3.11 or later
+- no package installation; runtime and tests use only the Python standard library
+
+Do not place a private Vault inside this repository. Keep it in a user-controlled local directory and pass that directory explicitly.
+
+## Usage
+
+Run commands from the repository root. `--vault-root` must be an absolute path.
+
+```powershell
+$VaultRoot = 'C:\path\to\already-readable-vault'
+$Adapter = 'yichen-wechat-windows-readonly\scripts\windows_readonly_adapter.py'
+
+# Metadata only; no consent flag is needed.
+python $Adapter --vault-root $VaultRoot status
+
+# These commands return private local data and require consent every time.
+python $Adapter --vault-root $VaultRoot --allow-private-content sessions --limit 20
+python $Adapter --vault-root $VaultRoot --allow-private-content contacts --query 'Casey'
+python $Adapter --vault-root $VaultRoot --allow-private-content history 'Casey' --limit 100
+python $Adapter --vault-root $VaultRoot --allow-private-content search 'review' --limit 100
+python $Adapter --vault-root $VaultRoot --allow-private-content stats 'Project Lantern'
+```
+
+All output is JSON. Contacts receive an opaque `contact_id`; if a display-name query matches more than one contact, the command returns candidate IDs and requires the caller to choose one.
+
+Dates use ISO 8601. A date without a time is interpreted in UTC; `--end YYYY-MM-DD` includes that entire UTC day.
+
+## Read-only and privacy guarantees
+
+- The adapter never guesses a path and never scans Documents, Desktop, OneDrive, or other common directories.
+- Path components that are links or Windows reparse points are rejected.
+- The source database and any WAL sidecar are copied to a system temporary directory only after stability checks. Queries open the temporary copy with SQLite `mode=ro` and `query_only` enabled.
+- If the source changes while the snapshot is made, the command fails. There is no result cache to fall back to.
+- Corrupt files and unsupported schemas fail closed.
+- Absolute paths, Windows usernames, internal account identifiers, and database secrets are not returned.
+- Stored text is treated as untrusted data and is JSON-serialized, never executed.
+- Non-text messages may be counted and type-labelled, but their bodies are always omitted.
 
 ## Explicitly unsupported
 
-This project does not obtain credentials, decrypt databases, attach to or control WeChat, inspect process memory, inject code, hook APIs, parse images or audio, change Codex/Hermes/MCP configuration, or export/upload private data by default.
+This project does not obtain credentials, decrypt databases, attach to or control WeChat, inspect process memory, inject code, hook APIs, parse image/audio content, change Codex/Hermes/MCP configuration, or export/upload private data by default.
 
-It is not a general Windows WeChat parser and does not claim compatibility with every WeChat database version.
+It does not claim compatibility with every WeChat database version.
 
-## Privacy model
+## Tests
 
-- `status` is metadata-only and does not return chat or contact content.
-- Content-bearing commands require a local `--allow-private-content` flag on every invocation.
-- Absolute paths, Windows usernames, internal account identifiers, and database secrets are never printed.
-- Source databases are never opened for writing. Query work is performed on a temporary snapshot and no cache is used.
-- All database content is treated as untrusted input and is returned only as data.
+```powershell
+$env:PYTHONDONTWRITEBYTECODE = '1'
+python -m unittest discover -s yichen-wechat-windows-readonly\tests -v
+git diff --check
+```
 
-## Installation
-
-Python 3.11 or later is required. The adapter uses only the Python standard library and installs no package dependencies.
-
-The command-line implementation is intentionally delivered in a separate implementation commit after this audit skeleton.
-
-## Repository safety
-
-Only synthetic test data belongs in this directory. Do not add real chat records, account identifiers, databases, credentials, or personal absolute paths.
+The suite creates only fictional databases in temporary directories and covers consent, redaction, path rejection, WAL visibility, corruption, concurrent mutation, fail-closed behavior, ambiguous contacts, read-only source preservation, non-text omission, sessions, contacts, history, search, and statistics.

--- a/yichen-wechat-windows-readonly/README.md
+++ b/yichen-wechat-windows-readonly/README.md
@@ -1,0 +1,38 @@
+# Windows Read-Only Adapter
+
+This skill is a narrowly scoped adapter for inspecting and querying an explicitly selected, already-decrypted local WeChat Vault copy on Windows.
+
+## Scope
+
+The adapter will provide:
+
+- metadata-only diagnostics for a Vault root supplied with `--vault-root`;
+- read-only session and contact queries;
+- read-only text history search and message statistics;
+- fail-closed handling for invalid paths, corrupt SQLite files, WAL snapshots, concurrent changes, and ambiguous contacts.
+
+The Vault root is never guessed. The adapter does not scan Documents, Desktop, OneDrive, or any other common user directory.
+
+## Explicitly unsupported
+
+This project does not obtain credentials, decrypt databases, attach to or control WeChat, inspect process memory, inject code, hook APIs, parse images or audio, change Codex/Hermes/MCP configuration, or export/upload private data by default.
+
+It is not a general Windows WeChat parser and does not claim compatibility with every WeChat database version.
+
+## Privacy model
+
+- `status` is metadata-only and does not return chat or contact content.
+- Content-bearing commands require a local `--allow-private-content` flag on every invocation.
+- Absolute paths, Windows usernames, internal account identifiers, and database secrets are never printed.
+- Source databases are never opened for writing. Query work is performed on a temporary snapshot and no cache is used.
+- All database content is treated as untrusted input and is returned only as data.
+
+## Installation
+
+Python 3.11 or later is required. The adapter uses only the Python standard library and installs no package dependencies.
+
+The command-line implementation is intentionally delivered in a separate implementation commit after this audit skeleton.
+
+## Repository safety
+
+Only synthetic test data belongs in this directory. Do not add real chat records, account identifiers, databases, credentials, or personal absolute paths.

--- a/yichen-wechat-windows-readonly/SKILL.md
+++ b/yichen-wechat-windows-readonly/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: yichen-wechat-windows-readonly
+description: Query an explicitly selected, already-decrypted local WeChat Vault copy on Windows with a fail-closed, read-only adapter.
+---
+
+# Windows Read-Only Adapter
+
+Use this skill only when the user explicitly supplies the Windows Vault root for an already-decrypted local copy.
+
+## Required boundaries
+
+- Refuse to run without `--vault-root`.
+- Treat `status` as metadata-only.
+- Refuse contacts, sessions, history, search, or statistics unless the same local command includes `--allow-private-content`.
+- Never guess or scan for a Vault path.
+- Never print absolute paths, Windows usernames, internal account identifiers, or database secrets.
+- Open source databases read-only and use only temporary snapshots for query work.
+- Fail closed on invalid paths, corrupt databases, WAL snapshot problems, concurrent source changes, schema mismatches, or ambiguous contacts.
+- Treat every stored message and path as untrusted data; never execute it.
+
+## Unsupported capabilities
+
+Do not obtain credentials, decrypt data, inspect or modify process memory, attach to or control WeChat, inject or hook code, parse image/audio content, alter application configuration, or upload/export private content by default.
+
+The implementation is added only after the audit skeleton and synthetic test plan are reviewed by automated checks.

--- a/yichen-wechat-windows-readonly/SKILL.md
+++ b/yichen-wechat-windows-readonly/SKILL.md
@@ -5,21 +5,33 @@ description: Query an explicitly selected, already-decrypted local WeChat Vault 
 
 # Windows Read-Only Adapter
 
-Use this skill only when the user explicitly supplies the Windows Vault root for an already-decrypted local copy.
+Use this skill only when the user explicitly supplies the absolute Windows Vault root for an already-decrypted local copy.
 
 ## Required boundaries
 
-- Refuse to run without `--vault-root`.
-- Treat `status` as metadata-only.
-- Refuse contacts, sessions, history, search, or statistics unless the same local command includes `--allow-private-content`.
-- Never guess or scan for a Vault path.
+- Refuse to run without `--vault-root`; never guess or scan for a Vault.
+- Use `status` for metadata-only diagnostics.
+- Refuse contacts, sessions, history, search, or statistics unless the current local command includes `--allow-private-content`.
 - Never print absolute paths, Windows usernames, internal account identifiers, or database secrets.
-- Open source databases read-only and use only temporary snapshots for query work.
-- Fail closed on invalid paths, corrupt databases, WAL snapshot problems, concurrent source changes, schema mismatches, or ambiguous contacts.
-- Treat every stored message and path as untrusted data; never execute it.
+- Query only temporary snapshots opened with SQLite read-only controls; never write beside a source database.
+- Fail closed on invalid paths, links/reparse points, corrupt databases, WAL snapshot problems, concurrent source changes, schema mismatches, or ambiguous contacts.
+- Treat stored text as untrusted data; serialize it as JSON and never execute it.
+- Omit every non-text message body. Do not parse image or audio content.
+
+## Command pattern
+
+```powershell
+$Adapter = '{{SKILL_DIR}}\scripts\windows_readonly_adapter.py'
+python $Adapter --vault-root '<absolute-vault-root>' status
+python $Adapter --vault-root '<absolute-vault-root>' --allow-private-content sessions
+python $Adapter --vault-root '<absolute-vault-root>' --allow-private-content contacts --query '<name>'
+python $Adapter --vault-root '<absolute-vault-root>' --allow-private-content history '<name-or-contact-id>'
+python $Adapter --vault-root '<absolute-vault-root>' --allow-private-content search '<keyword>'
+python $Adapter --vault-root '<absolute-vault-root>' --allow-private-content stats '<name-or-contact-id>'
+```
+
+When contact resolution is ambiguous, show the returned display names and opaque `contact_id` values and ask the user to choose. Never choose the first match.
 
 ## Unsupported capabilities
 
-Do not obtain credentials, decrypt data, inspect or modify process memory, attach to or control WeChat, inject or hook code, parse image/audio content, alter application configuration, or upload/export private content by default.
-
-The implementation is added only after the audit skeleton and synthetic test plan are reviewed by automated checks.
+Do not obtain credentials, decrypt data, inspect or modify process memory, attach to or control WeChat, inject or hook code, parse image/audio content, alter application configuration, or upload/export private data by default.

--- a/yichen-wechat-windows-readonly/THIRD_PARTY.md
+++ b/yichen-wechat-windows-readonly/THIRD_PARTY.md
@@ -1,0 +1,15 @@
+# Third-Party Dependencies and Licenses
+
+## Runtime dependencies
+
+None. The adapter and its tests use only the Python 3.11+ standard library.
+
+No package manager lockfile is needed because there are no installable third-party packages to resolve or lock.
+
+## Bundled third-party material
+
+None. No external source code, binary, database, fixture, media, or generated artifact is bundled.
+
+## Repository license
+
+This contribution is covered by the repository's root `LICENSE`. Python itself is a user-supplied runtime and is not redistributed by this contribution.

--- a/yichen-wechat-windows-readonly/THIRD_PARTY.md
+++ b/yichen-wechat-windows-readonly/THIRD_PARTY.md
@@ -6,10 +6,21 @@ None. The adapter and its tests use only the Python 3.11+ standard library.
 
 No package manager lockfile is needed because there are no installable third-party packages to resolve or lock.
 
+## CI actions
+
+The workflow uses the same official, commit-pinned actions already present at the clean baseline:
+
+| Action | Integrity pin | License | Source |
+| --- | --- | --- | --- |
+| `actions/checkout` v7.0.1 | `3d3c42e5aac5ba805825da76410c181273ba90b1` | MIT | Official `actions/checkout` GitHub repository |
+| `actions/setup-python` v7.0.0 | `5fda3b95a4ea91299a34e894583c3862153e4b97` | MIT | Official `actions/setup-python` GitHub repository |
+
+No floating action tag is used.
+
 ## Bundled third-party material
 
 None. No external source code, binary, database, fixture, media, or generated artifact is bundled.
 
 ## Repository license
 
-This contribution is covered by the repository's root `LICENSE`. Python itself is a user-supplied runtime and is not redistributed by this contribution.
+This contribution is covered by the repository's root `LICENSE`. Python itself is a user-supplied runtime and is not redistributed by this contribution. The two CI actions run remotely and are not bundled.

--- a/yichen-wechat-windows-readonly/scripts/windows_readonly_adapter.py
+++ b/yichen-wechat-windows-readonly/scripts/windows_readonly_adapter.py
@@ -1,0 +1,921 @@
+#!/usr/bin/env python3
+"""Fail-closed queries for an explicitly selected, already-readable Vault."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import sqlite3
+import stat
+import tempfile
+from collections import Counter
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from pathlib import Path
+from typing import Iterator, Sequence
+
+
+MESSAGE_TABLE_RE = re.compile(r"^Msg_[0-9a-f]{32}$")
+MESSAGE_DATABASE_RE = re.compile(r"^message_[0-9A-Za-z_-]+\.db$")
+MAX_CONTENT_LENGTH = 10_000
+MAX_LABEL_LENGTH = 256
+MAX_QUERY_LIMIT = 500
+
+TYPE_LABELS = {
+    1: "text",
+    3: "image",
+    34: "audio",
+    43: "video",
+    47: "sticker",
+    48: "location",
+    49: "link",
+    10000: "system",
+}
+
+
+class AdapterError(Exception):
+    """A controlled error whose message is safe to return to the caller."""
+
+    def __init__(self, code: str, message: str, details: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+
+@dataclass(frozen=True)
+class FileState:
+    size: int
+    modified_ns: int
+    inode: int
+    device: int
+
+
+@dataclass(frozen=True)
+class Contact:
+    username: str
+    display_name: str
+    remark: str
+    nickname: str
+    alias: str
+    is_group: bool
+
+    @property
+    def contact_id(self) -> str:
+        digest = hashlib.sha256(self.username.encode("utf-8")).hexdigest()[:16]
+        return f"contact-{digest}"
+
+    def public(self) -> dict:
+        return {
+            "contact_id": self.contact_id,
+            "display_name": self.display_name,
+            "is_group": self.is_group,
+        }
+
+
+def _bounded_text(value: object, limit: int) -> str:
+    text = str(value or "").replace("\x00", "")
+    return text[:limit]
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        info = path.lstat()
+    except OSError:
+        return False
+    attributes = int(getattr(info, "st_file_attributes", 0) or 0)
+    flag = int(getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+    return path.is_symlink() or bool(attributes & flag)
+
+
+def _reject_reparse_components(path: Path) -> None:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        if current.exists() and _is_reparse_point(current):
+            raise AdapterError(
+                "reparse_point_rejected",
+                "The selected Vault path contains a link or reparse point.",
+            )
+
+
+def resolve_vault_root(value: str) -> Path:
+    supplied = Path(value)
+    if not supplied.is_absolute():
+        raise AdapterError("invalid_vault_root", "--vault-root must be an absolute path.")
+    try:
+        _reject_reparse_components(supplied)
+        root = supplied.resolve(strict=True)
+    except AdapterError:
+        raise
+    except OSError as exc:
+        raise AdapterError("invalid_vault_root", "The selected Vault root is unavailable.") from exc
+    if not root.is_dir():
+        raise AdapterError("invalid_vault_root", "The selected Vault root is not a directory.")
+    return root
+
+
+def _validate_database(root: Path, relative: Path) -> Path:
+    candidate = root / relative
+    try:
+        _reject_reparse_components(candidate)
+        resolved = candidate.resolve(strict=True)
+    except AdapterError:
+        raise
+    except OSError as exc:
+        raise AdapterError("database_unavailable", "A required selected database is unavailable.") from exc
+    if not resolved.is_relative_to(root) or not resolved.is_file() or resolved.suffix.lower() != ".db":
+        raise AdapterError("database_unavailable", "A required selected database is unavailable.")
+    return resolved
+
+
+def _optional_database(root: Path, relative: Path) -> Path | None:
+    candidate = root / relative
+    if not candidate.exists():
+        return None
+    return _validate_database(root, relative)
+
+
+def discover_message_databases(root: Path) -> list[Path]:
+    directory = root / "message"
+    if not directory.exists():
+        return []
+    _reject_reparse_components(directory)
+    if not directory.is_dir():
+        raise AdapterError("invalid_vault_layout", "The selected Vault message location is invalid.")
+    paths = []
+    try:
+        entries = sorted(directory.iterdir(), key=lambda item: item.name)
+    except OSError as exc:
+        raise AdapterError("database_unavailable", "The selected message databases are unavailable.") from exc
+    for entry in entries:
+        if MESSAGE_DATABASE_RE.fullmatch(entry.name):
+            paths.append(_validate_database(root, Path("message") / entry.name))
+    return paths
+
+
+def _file_state(path: Path) -> FileState:
+    try:
+        info = path.stat()
+    except OSError as exc:
+        raise AdapterError("database_unavailable", "A selected database became unavailable.") from exc
+    return FileState(info.st_size, info.st_mtime_ns, info.st_ino, info.st_dev)
+
+
+def _database_state(path: Path) -> tuple[FileState, FileState | None]:
+    wal = Path(f"{path}-wal")
+    wal_state = None
+    if wal.exists():
+        if _is_reparse_point(wal) or not wal.is_file():
+            raise AdapterError("invalid_wal", "A selected database has an invalid WAL sidecar.")
+        wal_state = _file_state(wal)
+    return _file_state(path), wal_state
+
+
+@contextmanager
+def snapshot_databases(paths: Sequence[Path]) -> Iterator[dict[Path, Path]]:
+    """Copy stable database/WAL pairs to a temporary query-only workspace."""
+
+    unique_paths = list(dict.fromkeys(paths))
+    if not unique_paths:
+        raise AdapterError("database_unavailable", "No selected database is available for this query.")
+    before = {path: _database_state(path) for path in unique_paths}
+    with tempfile.TemporaryDirectory(prefix="yichen-wechat-readonly-") as temp_value:
+        temp_root = Path(temp_value)
+        copies: dict[Path, Path] = {}
+        try:
+            for index, source in enumerate(unique_paths):
+                destination_dir = temp_root / f"db-{index}"
+                destination_dir.mkdir()
+                destination = destination_dir / source.name
+                shutil.copyfile(source, destination)
+                if before[source][1] is not None:
+                    shutil.copyfile(Path(f"{source}-wal"), Path(f"{destination}-wal"))
+                copies[source] = destination
+        except OSError as exc:
+            raise AdapterError("snapshot_failed", "The selected databases could not be snapshotted safely.") from exc
+
+        after = {path: _database_state(path) for path in unique_paths}
+        if before != after:
+            raise AdapterError(
+                "source_changed",
+                "A selected database changed during the read-only snapshot; retry after it is stable.",
+            )
+        yield copies
+
+
+@contextmanager
+def connect_readonly(path: Path) -> Iterator[sqlite3.Connection]:
+    connection: sqlite3.Connection | None = None
+    try:
+        connection = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True, timeout=1.0)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA query_only=ON")
+        connection.execute("PRAGMA trusted_schema=OFF")
+        result = [str(row[0]) for row in connection.execute("PRAGMA quick_check")]
+        if result != ["ok"]:
+            raise AdapterError("corrupt_database", "A selected database is corrupt or unreadable.")
+        yield connection
+    except AdapterError:
+        raise
+    except sqlite3.Error as exc:
+        raise AdapterError("corrupt_database", "A selected database is corrupt or unreadable.") from exc
+    finally:
+        if connection is not None:
+            connection.close()
+
+
+def _table_exists(connection: sqlite3.Connection, table: str) -> bool:
+    row = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    return bool(row)
+
+
+def _table_columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    if table not in {"contact", "SessionTable", "Name2Id"} and not MESSAGE_TABLE_RE.fullmatch(table):
+        raise AdapterError("unsupported_schema", "A selected database contains an unsupported table name.")
+    return {str(row[1]) for row in connection.execute(f"PRAGMA table_info([{table}])")}
+
+
+def _choose_column(columns: set[str], *choices: str, required: bool = False) -> str | None:
+    for choice in choices:
+        if choice in columns:
+            return choice
+    if required:
+        raise AdapterError("unsupported_schema", "A selected database has an unsupported schema.")
+    return None
+
+
+def _select_expression(column: str | None, alias: str) -> str:
+    return f"[{column}] AS [{alias}]" if column else f"NULL AS [{alias}]"
+
+
+def load_contacts(connection: sqlite3.Connection) -> tuple[list[Contact], dict[str, Contact]]:
+    if not _table_exists(connection, "contact"):
+        raise AdapterError("unsupported_schema", "The contact database has an unsupported schema.")
+    columns = _table_columns(connection, "contact")
+    username = _choose_column(columns, "username", "userName", required=True)
+    nickname = _choose_column(columns, "nick_name", "nickname")
+    remark = _choose_column(columns, "remark")
+    alias = _choose_column(columns, "alias")
+    sql = "SELECT " + ", ".join(
+        (
+            _select_expression(username, "username"),
+            _select_expression(nickname, "nickname"),
+            _select_expression(remark, "remark"),
+            _select_expression(alias, "alias"),
+        )
+    ) + " FROM [contact]"
+    contacts = []
+    by_username = {}
+    for row in connection.execute(sql):
+        internal_name = _bounded_text(row["username"], MAX_LABEL_LENGTH)
+        if not internal_name:
+            continue
+        safe_remark = _bounded_text(row["remark"], MAX_LABEL_LENGTH)
+        safe_nickname = _bounded_text(row["nickname"], MAX_LABEL_LENGTH)
+        safe_alias = _bounded_text(row["alias"], MAX_LABEL_LENGTH)
+        display = safe_remark or safe_nickname or "Unnamed contact"
+        contact = Contact(
+            username=internal_name,
+            display_name=display,
+            remark=safe_remark,
+            nickname=safe_nickname,
+            alias=safe_alias,
+            is_group="@chatroom" in internal_name,
+        )
+        contacts.append(contact)
+        by_username[internal_name] = contact
+    return contacts, by_username
+
+
+def resolve_contact(query: str, contacts: Sequence[Contact]) -> Contact:
+    normalized = query.strip().casefold()
+    if not normalized:
+        raise AdapterError("contact_not_found", "A contact name or contact_id is required.")
+    id_matches = [contact for contact in contacts if contact.contact_id.casefold() == normalized]
+    if id_matches:
+        return id_matches[0]
+    exact = [
+        contact
+        for contact in contacts
+        if normalized in {
+            contact.display_name.casefold(),
+            contact.remark.casefold(),
+            contact.nickname.casefold(),
+            contact.alias.casefold(),
+        }
+    ]
+    matches = exact or [
+        contact
+        for contact in contacts
+        if any(
+            normalized in value.casefold()
+            for value in (contact.display_name, contact.remark, contact.nickname, contact.alias)
+            if value
+        )
+    ]
+    if not matches:
+        raise AdapterError("contact_not_found", "No matching contact was found in the selected Vault.")
+    if len(matches) > 1:
+        candidates = [contact.public() for contact in sorted(matches, key=lambda item: item.contact_id)]
+        raise AdapterError(
+            "ambiguous_contact",
+            "Multiple contacts match; retry with one returned contact_id.",
+            {"candidates": candidates},
+        )
+    return matches[0]
+
+
+def _base_message_type(value: object) -> int:
+    try:
+        return int(value or 0) & 0xFFFFFFFF
+    except (TypeError, ValueError):
+        return 0
+
+
+def _type_label(value: object) -> str:
+    base = _base_message_type(value)
+    return TYPE_LABELS.get(base, f"type-{base}")
+
+
+def _safe_message_content(value: object) -> str | None:
+    if isinstance(value, str):
+        return _bounded_text(value, MAX_CONTENT_LENGTH)
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8", errors="strict")[:MAX_CONTENT_LENGTH]
+        except UnicodeDecodeError:
+            return None
+    return None
+
+
+def _iso_timestamp(value: object) -> str:
+    try:
+        timestamp = int(value or 0)
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()
+    except (OverflowError, OSError, TypeError, ValueError):
+        return ""
+
+
+def _parse_time(value: str | None, *, end_of_day: bool = False) -> int | None:
+    if value is None:
+        return None
+    try:
+        if len(value) == 10:
+            parsed_date = date.fromisoformat(value)
+            parsed = datetime.combine(parsed_date, time.max if end_of_day else time.min, timezone.utc)
+        else:
+            parsed = datetime.fromisoformat(value)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+        return int(parsed.timestamp())
+    except ValueError as exc:
+        raise AdapterError("invalid_time", "Time values must use ISO 8601 format.") from exc
+
+
+def _positive_limit(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1 or parsed > MAX_QUERY_LIMIT:
+        raise argparse.ArgumentTypeError(f"limit must be between 1 and {MAX_QUERY_LIMIT}")
+    return parsed
+
+
+def _nonnegative(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("offset must be nonnegative")
+    return parsed
+
+
+def _message_table(username: str) -> str:
+    return "Msg_" + hashlib.md5(username.encode("utf-8")).hexdigest()
+
+
+def _message_columns(connection: sqlite3.Connection, table: str) -> dict[str, str | None]:
+    columns = _table_columns(connection, table)
+    return {
+        "local_id": _choose_column(columns, "local_id", "id"),
+        "local_type": _choose_column(columns, "local_type", "type", required=True),
+        "create_time": _choose_column(columns, "create_time", "timestamp", required=True),
+        "real_sender_id": _choose_column(columns, "real_sender_id", "sender_id"),
+        "message_content": _choose_column(columns, "message_content", "content"),
+    }
+
+
+def _name_to_id(connection: sqlite3.Connection) -> dict[int, str]:
+    if not _table_exists(connection, "Name2Id"):
+        return {}
+    columns = _table_columns(connection, "Name2Id")
+    if "user_name" not in columns:
+        return {}
+    mapping = {}
+    for row in connection.execute("SELECT rowid, user_name FROM [Name2Id]"):
+        try:
+            mapping[int(row[0])] = _bounded_text(row[1], MAX_LABEL_LENGTH)
+        except (TypeError, ValueError):
+            continue
+    return mapping
+
+
+def _username_for_table(table: str, connection: sqlite3.Connection, contacts: Sequence[Contact]) -> str:
+    target = table[4:]
+    for username in _name_to_id(connection).values():
+        if hashlib.md5(username.encode("utf-8")).hexdigest() == target:
+            return username
+    for contact in contacts:
+        if hashlib.md5(contact.username.encode("utf-8")).hexdigest() == target:
+            return contact.username
+    return ""
+
+
+def _message_tables(connection: sqlite3.Connection) -> list[str]:
+    tables = []
+    for row in connection.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'Msg_%' ORDER BY name"
+    ):
+        name = str(row[0] or "")
+        if MESSAGE_TABLE_RE.fullmatch(name):
+            tables.append(name)
+    return tables
+
+
+def _where_for_time(columns: dict[str, str | None], start: int | None, end: int | None) -> tuple[list[str], list]:
+    clauses = []
+    parameters: list = []
+    create_time = columns["create_time"]
+    if start is not None:
+        clauses.append(f"[{create_time}] >= ?")
+        parameters.append(start)
+    if end is not None:
+        clauses.append(f"[{create_time}] <= ?")
+        parameters.append(end)
+    return clauses, parameters
+
+
+def _message_row(
+    row: sqlite3.Row,
+    contact: Contact,
+    contacts_by_username: dict[str, Contact],
+    name_ids: dict[int, str],
+) -> dict:
+    local_type = row["local_type"]
+    base_type = _base_message_type(local_type)
+    sender_username = ""
+    try:
+        sender_username = name_ids.get(int(row["real_sender_id"] or 0), "")
+    except (TypeError, ValueError):
+        pass
+    sender_contact = contacts_by_username.get(sender_username)
+    sender = sender_contact.display_name if sender_contact else contact.display_name
+    item = {
+        "message_id": str(row["local_id"] or ""),
+        "message_type": _type_label(local_type),
+        "sender": sender,
+        "timestamp": int(row["create_time"] or 0),
+        "time_utc": _iso_timestamp(row["create_time"]),
+    }
+    if base_type == 1:
+        content = _safe_message_content(row["message_content"])
+        item["content"] = content
+        item["content_omitted"] = content is None
+    else:
+        item["content"] = None
+        item["content_omitted"] = True
+    return item
+
+
+def _collect_history(
+    contact: Contact,
+    contacts_by_username: dict[str, Contact],
+    message_paths: Sequence[Path],
+    copies: dict[Path, Path],
+    start: int | None,
+    end: int | None,
+    limit: int,
+    offset: int,
+) -> list[dict]:
+    table = _message_table(contact.username)
+    collected = []
+    for source in message_paths:
+        with connect_readonly(copies[source]) as connection:
+            if not _table_exists(connection, table):
+                continue
+            columns = _message_columns(connection, table)
+            clauses, parameters = _where_for_time(columns, start, end)
+            where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+            expressions = (
+                _select_expression(columns["local_id"], "local_id"),
+                _select_expression(columns["local_type"], "local_type"),
+                _select_expression(columns["create_time"], "create_time"),
+                _select_expression(columns["real_sender_id"], "real_sender_id"),
+                _select_expression(columns["message_content"], "message_content"),
+            )
+            sql = f"SELECT {', '.join(expressions)} FROM [{table}]{where} ORDER BY [create_time] DESC LIMIT ?"
+            parameters.append(limit + offset)
+            name_ids = _name_to_id(connection)
+            for row in connection.execute(sql, parameters):
+                collected.append(_message_row(row, contact, contacts_by_username, name_ids))
+    collected.sort(key=lambda item: (item["timestamp"], item["message_id"]), reverse=True)
+    page = collected[offset : offset + limit]
+    page.sort(key=lambda item: (item["timestamp"], item["message_id"]))
+    return page
+
+
+def _load_contacts_from_copy(contact_source: Path, copies: dict[Path, Path]) -> tuple[list[Contact], dict[str, Contact]]:
+    with connect_readonly(copies[contact_source]) as connection:
+        return load_contacts(connection)
+
+
+def command_status(root: Path) -> dict:
+    contact = _optional_database(root, Path("contact/contact.db"))
+    session = _optional_database(root, Path("session/session.db"))
+    messages = discover_message_databases(root)
+    if not any((contact, session, messages)):
+        raise AdapterError("unsupported_vault", "The selected Vault has no supported database copy.")
+
+    def health(path: Path) -> tuple[bool, str | None, bool]:
+        wal_present = Path(f"{path}-wal").exists()
+        try:
+            with snapshot_databases([path]) as copies:
+                with connect_readonly(copies[path]):
+                    pass
+            return True, None, wal_present
+        except AdapterError as exc:
+            return False, exc.code, wal_present
+
+    result = {
+        "vault": "explicitly-selected",
+        "metadata_only": True,
+        "contacts": {"available": contact is not None},
+        "sessions": {"available": session is not None},
+        "messages": {"available_count": len(messages)},
+    }
+    if contact:
+        healthy, issue, wal = health(contact)
+        result["contacts"].update({"healthy": healthy, "issue": issue, "wal_present": wal})
+    if session:
+        healthy, issue, wal = health(session)
+        result["sessions"].update({"healthy": healthy, "issue": issue, "wal_present": wal})
+    message_health = [health(path) for path in messages]
+    result["messages"].update(
+        {
+            "healthy_count": sum(1 for healthy, _, _ in message_health if healthy),
+            "unhealthy_count": sum(1 for healthy, _, _ in message_health if not healthy),
+            "wal_count": sum(1 for _, _, wal in message_health if wal),
+            "issues": sorted({issue for _, issue, _ in message_health if issue}),
+        }
+    )
+    return result
+
+
+def command_contacts(root: Path, query: str | None, limit: int) -> dict:
+    source = _validate_database(root, Path("contact/contact.db"))
+    with snapshot_databases([source]) as copies:
+        contacts, _ = _load_contacts_from_copy(source, copies)
+    if query:
+        normalized = query.casefold()
+        contacts = [
+            contact
+            for contact in contacts
+            if any(
+                normalized in value.casefold()
+                for value in (contact.display_name, contact.remark, contact.nickname, contact.alias)
+                if value
+            )
+        ]
+    contacts.sort(key=lambda item: (not item.is_group, item.display_name.casefold(), item.contact_id))
+    public = [contact.public() for contact in contacts[:limit]]
+    return {"count": len(public), "contacts": public}
+
+
+def command_sessions(root: Path, limit: int) -> dict:
+    session_source = _validate_database(root, Path("session/session.db"))
+    contact_source = _optional_database(root, Path("contact/contact.db"))
+    sources = [session_source] + ([contact_source] if contact_source else [])
+    with snapshot_databases(sources) as copies:
+        contacts_by_username: dict[str, Contact] = {}
+        if contact_source:
+            _, contacts_by_username = _load_contacts_from_copy(contact_source, copies)
+        with connect_readonly(copies[session_source]) as connection:
+            if not _table_exists(connection, "SessionTable"):
+                raise AdapterError("unsupported_schema", "The session database has an unsupported schema.")
+            columns = _table_columns(connection, "SessionTable")
+            required = {
+                "username",
+                "unread_count",
+                "summary",
+                "last_timestamp",
+                "last_msg_type",
+                "last_msg_sender",
+                "last_sender_display_name",
+            }
+            if not required.issubset(columns):
+                raise AdapterError("unsupported_schema", "The session database has an unsupported schema.")
+            rows = connection.execute(
+                """
+                SELECT username, unread_count, summary, last_timestamp,
+                       last_msg_type, last_msg_sender, last_sender_display_name
+                FROM SessionTable
+                WHERE last_timestamp > 0
+                ORDER BY last_timestamp DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+    sessions = []
+    for row in rows:
+        internal_name = _bounded_text(row["username"], MAX_LABEL_LENGTH)
+        contact = contacts_by_username.get(internal_name)
+        display = contact.display_name if contact else "Unnamed contact"
+        contact_id = contact.contact_id if contact else f"contact-{hashlib.sha256(internal_name.encode()).hexdigest()[:16]}"
+        sender_internal = _bounded_text(row["last_msg_sender"], MAX_LABEL_LENGTH)
+        sender_contact = contacts_by_username.get(sender_internal)
+        sender = sender_contact.display_name if sender_contact else _bounded_text(
+            row["last_sender_display_name"], MAX_LABEL_LENGTH
+        )
+        message_type = _type_label(row["last_msg_type"])
+        summary = _safe_message_content(row["summary"]) if _base_message_type(row["last_msg_type"]) == 1 else None
+        if summary and ":\n" in summary:
+            summary = summary.split(":\n", 1)[1]
+        sessions.append(
+            {
+                "contact_id": contact_id,
+                "display_name": display,
+                "is_group": contact.is_group if contact else False,
+                "unread": int(row["unread_count"] or 0),
+                "last_message_type": message_type,
+                "last_message": summary,
+                "last_message_omitted": summary is None,
+                "sender": sender,
+                "timestamp": int(row["last_timestamp"] or 0),
+                "time_utc": _iso_timestamp(row["last_timestamp"]),
+            }
+        )
+    return {"count": len(sessions), "sessions": sessions}
+
+
+def _contacts_and_messages(root: Path) -> tuple[Path, list[Path]]:
+    contact_source = _validate_database(root, Path("contact/contact.db"))
+    messages = discover_message_databases(root)
+    if not messages:
+        raise AdapterError("database_unavailable", "No selected message database is available.")
+    return contact_source, messages
+
+
+def command_history(
+    root: Path,
+    chat: str,
+    start_value: str | None,
+    end_value: str | None,
+    limit: int,
+    offset: int,
+) -> dict:
+    contact_source, message_sources = _contacts_and_messages(root)
+    sources = [contact_source, *message_sources]
+    with snapshot_databases(sources) as copies:
+        contacts, by_username = _load_contacts_from_copy(contact_source, copies)
+        contact = resolve_contact(chat, contacts)
+        rows = _collect_history(
+            contact,
+            by_username,
+            message_sources,
+            copies,
+            _parse_time(start_value),
+            _parse_time(end_value, end_of_day=True),
+            limit,
+            offset,
+        )
+    return {"contact": contact.public(), "count": len(rows), "messages": rows}
+
+
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def command_search(
+    root: Path,
+    keyword: str,
+    chat: str | None,
+    start_value: str | None,
+    end_value: str | None,
+    limit: int,
+    offset: int,
+) -> dict:
+    if not keyword:
+        raise AdapterError("invalid_query", "A non-empty search keyword is required.")
+    contact_source, message_sources = _contacts_and_messages(root)
+    sources = [contact_source, *message_sources]
+    with snapshot_databases(sources) as copies:
+        contacts, by_username = _load_contacts_from_copy(contact_source, copies)
+        selected = resolve_contact(chat, contacts) if chat else None
+        start = _parse_time(start_value)
+        end = _parse_time(end_value, end_of_day=True)
+        results = []
+        for source in message_sources:
+            with connect_readonly(copies[source]) as connection:
+                tables = [_message_table(selected.username)] if selected else _message_tables(connection)
+                name_ids = _name_to_id(connection)
+                for table in tables:
+                    if not _table_exists(connection, table):
+                        continue
+                    username = selected.username if selected else _username_for_table(table, connection, contacts)
+                    contact = by_username.get(username)
+                    if contact is None:
+                        continue
+                    columns = _message_columns(connection, table)
+                    content_column = columns["message_content"]
+                    if content_column is None:
+                        continue
+                    clauses, parameters = _where_for_time(columns, start, end)
+                    clauses.extend(
+                        (
+                            f"([{columns['local_type']}] & 4294967295) = 1",
+                            f"[{content_column}] LIKE ? ESCAPE '\\'",
+                        )
+                    )
+                    parameters.extend((f"%{_escape_like(keyword)}%", limit + offset))
+                    expressions = (
+                        _select_expression(columns["local_id"], "local_id"),
+                        _select_expression(columns["local_type"], "local_type"),
+                        _select_expression(columns["create_time"], "create_time"),
+                        _select_expression(columns["real_sender_id"], "real_sender_id"),
+                        _select_expression(content_column, "message_content"),
+                    )
+                    sql = (
+                        f"SELECT {', '.join(expressions)} FROM [{table}] "
+                        f"WHERE {' AND '.join(clauses)} ORDER BY [create_time] DESC LIMIT ?"
+                    )
+                    for row in connection.execute(sql, parameters):
+                        item = _message_row(row, contact, by_username, name_ids)
+                        content = item.get("content")
+                        if content is not None and keyword.casefold() in content.casefold():
+                            item["contact"] = contact.public()
+                            results.append(item)
+        results.sort(key=lambda item: (item["timestamp"], item["message_id"]), reverse=True)
+        page = results[offset : offset + limit]
+        page.sort(key=lambda item: (item["timestamp"], item["message_id"]))
+    return {"keyword": keyword, "count": len(page), "messages": page}
+
+
+def command_stats(
+    root: Path,
+    chat: str,
+    start_value: str | None,
+    end_value: str | None,
+) -> dict:
+    contact_source, message_sources = _contacts_and_messages(root)
+    sources = [contact_source, *message_sources]
+    with snapshot_databases(sources) as copies:
+        contacts, by_username = _load_contacts_from_copy(contact_source, copies)
+        contact = resolve_contact(chat, contacts)
+        table = _message_table(contact.username)
+        start = _parse_time(start_value)
+        end = _parse_time(end_value, end_of_day=True)
+        type_counts: Counter[str] = Counter()
+        sender_counts: Counter[str] = Counter()
+        hourly = {str(hour): 0 for hour in range(24)}
+        total = 0
+        for source in message_sources:
+            with connect_readonly(copies[source]) as connection:
+                if not _table_exists(connection, table):
+                    continue
+                columns = _message_columns(connection, table)
+                clauses, parameters = _where_for_time(columns, start, end)
+                where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+                for row in connection.execute(
+                    f"SELECT [{columns['local_type']}], COUNT(*) FROM [{table}]{where} GROUP BY [{columns['local_type']}]",
+                    parameters,
+                ):
+                    count = int(row[1] or 0)
+                    type_counts[_type_label(row[0])] += count
+                    total += count
+                sender_column = columns["real_sender_id"]
+                if sender_column:
+                    name_ids = _name_to_id(connection)
+                    for row in connection.execute(
+                        f"SELECT [{sender_column}], COUNT(*) FROM [{table}]{where} GROUP BY [{sender_column}]",
+                        parameters,
+                    ):
+                        try:
+                            sender_username = name_ids.get(int(row[0] or 0), "")
+                        except (TypeError, ValueError):
+                            sender_username = ""
+                        sender_contact = by_username.get(sender_username)
+                        sender = sender_contact.display_name if sender_contact else contact.display_name
+                        sender_counts[sender] += int(row[1] or 0)
+                for row in connection.execute(
+                    f"""
+                    SELECT strftime('%H', [{columns['create_time']}], 'unixepoch'), COUNT(*)
+                    FROM [{table}]{where}
+                    GROUP BY 1
+                    """,
+                    parameters,
+                ):
+                    if row[0] is not None:
+                        hourly[str(int(row[0]))] += int(row[1] or 0)
+    return {
+        "contact": contact.public(),
+        "total": total,
+        "type_breakdown": dict(type_counts.most_common()),
+        "top_senders": [
+            {"display_name": name, "count": count}
+            for name, count in sender_counts.most_common(10)
+        ],
+        "hourly_utc": hourly,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault-root", required=True, help="Absolute path to the explicitly selected Vault root")
+    parser.add_argument(
+        "--allow-private-content",
+        action="store_true",
+        help="Required on each invocation that returns contact or message data",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("status", help="Return metadata-only Vault diagnostics")
+
+    contacts = subparsers.add_parser("contacts", help="List or filter contacts")
+    contacts.add_argument("--query")
+    contacts.add_argument("--limit", type=_positive_limit, default=50)
+
+    sessions = subparsers.add_parser("sessions", help="List recent sessions")
+    sessions.add_argument("--limit", type=_positive_limit, default=20)
+
+    history = subparsers.add_parser("history", help="Return history for one unambiguous contact")
+    history.add_argument("chat", help="Display name or contact_id")
+    history.add_argument("--start")
+    history.add_argument("--end")
+    history.add_argument("--limit", type=_positive_limit, default=100)
+    history.add_argument("--offset", type=_nonnegative, default=0)
+
+    search = subparsers.add_parser("search", help="Search text history")
+    search.add_argument("keyword")
+    search.add_argument("--chat", help="Optional display name or contact_id")
+    search.add_argument("--start")
+    search.add_argument("--end")
+    search.add_argument("--limit", type=_positive_limit, default=100)
+    search.add_argument("--offset", type=_nonnegative, default=0)
+
+    stats = subparsers.add_parser("stats", help="Return message statistics for one contact")
+    stats.add_argument("chat", help="Display name or contact_id")
+    stats.add_argument("--start")
+    stats.add_argument("--end")
+    return parser
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        root = resolve_vault_root(args.vault_root)
+        if args.command != "status" and not args.allow_private_content:
+            raise AdapterError(
+                "consent_required",
+                "This command requires --allow-private-content on the current invocation.",
+            )
+        if args.command == "status":
+            result = command_status(root)
+        elif args.command == "contacts":
+            result = command_contacts(root, args.query, args.limit)
+        elif args.command == "sessions":
+            result = command_sessions(root, args.limit)
+        elif args.command == "history":
+            result = command_history(root, args.chat, args.start, args.end, args.limit, args.offset)
+        elif args.command == "search":
+            result = command_search(root, args.keyword, args.chat, args.start, args.end, args.limit, args.offset)
+        elif args.command == "stats":
+            result = command_stats(root, args.chat, args.start, args.end)
+        else:  # pragma: no cover - argparse guarantees a known command
+            raise AdapterError("invalid_command", "The requested command is not supported.")
+        print(json.dumps({"ok": True, "command": args.command, "result": result}, ensure_ascii=False, sort_keys=True))
+        return 0
+    except AdapterError as exc:
+        payload = {"ok": False, "error": {"code": exc.code, "message": exc.message}}
+        if exc.details:
+            payload["error"]["details"] = exc.details
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return 3
+    except (OSError, sqlite3.Error):
+        payload = {
+            "ok": False,
+            "error": {"code": "query_failed", "message": "The read-only query failed safely."},
+        }
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return 3
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/yichen-wechat-windows-readonly/tests/README.md
+++ b/yichen-wechat-windows-readonly/tests/README.md
@@ -19,10 +19,10 @@ All tests use temporary directories and synthetic SQLite databases generated loc
 13. Source files contain no prohibited runtime capability or disallowed dependency.
 14. `git diff --check` and the complete unit-test suite pass on Windows.
 
-## Planned commands
+## Commands
 
 ```powershell
-python tests/fixtures/build_synthetic_vault.py --output <temporary-directory>
-python -m unittest discover -s tests -v
+python yichen-wechat-windows-readonly/tests/fixtures/build_synthetic_vault.py --output <temporary-directory>
+python -m unittest discover -s yichen-wechat-windows-readonly/tests -v
 git diff --check
 ```

--- a/yichen-wechat-windows-readonly/tests/README.md
+++ b/yichen-wechat-windows-readonly/tests/README.md
@@ -1,0 +1,28 @@
+# Test Plan
+
+All tests use temporary directories and synthetic SQLite databases generated locally. No fixture contains real accounts, conversations, paths, credentials, or media.
+
+## Acceptance coverage
+
+1. `--vault-root` is mandatory and no common user directory is scanned.
+2. `status` returns only redacted metadata.
+3. Content-bearing commands fail without `--allow-private-content`.
+4. Sessions and contacts are queried from a synthetic, already-decrypted Vault.
+5. History and global search return only text content and never expose internal account identifiers.
+6. Statistics return counts and redacted display labels.
+7. Wrong roots, paths that escape the Vault, links/reparse points, unsupported schemas, and corrupt SQLite files fail closed.
+8. WAL-backed committed rows are visible from a stable temporary snapshot without writing beside the source database.
+9. A source that changes during snapshot creation fails closed and no cached result is returned.
+10. Ambiguous contact names return a selection error rather than choosing the first match.
+11. Non-text message bodies are omitted; image and audio payloads are not parsed.
+12. Output and errors do not disclose absolute paths, Windows usernames, internal account identifiers, or secrets.
+13. Source files contain no prohibited runtime capability or disallowed dependency.
+14. `git diff --check` and the complete unit-test suite pass on Windows.
+
+## Planned commands
+
+```powershell
+python tests/fixtures/build_synthetic_vault.py --output <temporary-directory>
+python -m unittest discover -s tests -v
+git diff --check
+```

--- a/yichen-wechat-windows-readonly/tests/fixtures/README.md
+++ b/yichen-wechat-windows-readonly/tests/fixtures/README.md
@@ -1,0 +1,13 @@
+# Synthetic Fixtures Only
+
+`build_synthetic_vault.py` creates a small fictional Vault under a caller-supplied output directory. The generated SQLite files are test artifacts and must not be committed.
+
+The fixture intentionally includes:
+
+- two contacts with the same display name for ambiguity tests;
+- one direct session and one group session;
+- plain text messages for history, search, and statistics;
+- one non-text message whose body must never be returned;
+- deterministic timestamps and fictional identifiers.
+
+Tests create additional temporary variants for WAL, corruption, invalid paths, and concurrent mutation.

--- a/yichen-wechat-windows-readonly/tests/fixtures/build_synthetic_vault.py
+++ b/yichen-wechat-windows-readonly/tests/fixtures/build_synthetic_vault.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 
@@ -23,7 +24,7 @@ def message_table(username: str) -> str:
 
 
 def create_contact_database(path: Path) -> None:
-    with sqlite3.connect(path) as connection:
+    with closing(sqlite3.connect(path)) as connection, connection:
         connection.execute(
             """
             CREATE TABLE contact (
@@ -43,7 +44,7 @@ def create_contact_database(path: Path) -> None:
 
 
 def create_session_database(path: Path) -> None:
-    with sqlite3.connect(path) as connection:
+    with closing(sqlite3.connect(path)) as connection, connection:
         connection.execute(
             """
             CREATE TABLE SessionTable (
@@ -80,7 +81,7 @@ def create_session_database(path: Path) -> None:
 
 
 def create_message_database(path: Path) -> None:
-    with sqlite3.connect(path) as connection:
+    with closing(sqlite3.connect(path)) as connection, connection:
         connection.execute("CREATE TABLE Name2Id (user_name TEXT NOT NULL)")
         connection.executemany(
             "INSERT INTO Name2Id (rowid, user_name) VALUES (?, ?)",

--- a/yichen-wechat-windows-readonly/tests/fixtures/build_synthetic_vault.py
+++ b/yichen-wechat-windows-readonly/tests/fixtures/build_synthetic_vault.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Build a fictional, already-decrypted Vault for local tests."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sqlite3
+from pathlib import Path
+
+
+CONTACTS = (
+    (1, "synthetic_alex_one", "Alex", "Alex", "alex-one"),
+    (2, "synthetic_alex_two", "Alex", "Alex", "alex-two"),
+    (3, "synthetic_casey", "Casey", "Casey", "casey"),
+    (4, "synthetic_project@chatroom", "Project Lantern", "Project Lantern", ""),
+    (5, "synthetic_morgan", "Morgan", "Morgan", "morgan"),
+)
+
+
+def message_table(username: str) -> str:
+    return "Msg_" + hashlib.md5(username.encode("utf-8")).hexdigest()
+
+
+def create_contact_database(path: Path) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE contact (
+                id INTEGER PRIMARY KEY,
+                username TEXT NOT NULL,
+                nick_name TEXT,
+                remark TEXT,
+                alias TEXT,
+                description TEXT
+            )
+            """
+        )
+        connection.executemany(
+            "INSERT INTO contact (id, username, nick_name, remark, alias, description) VALUES (?, ?, ?, ?, ?, '')",
+            CONTACTS,
+        )
+
+
+def create_session_database(path: Path) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE SessionTable (
+                username TEXT NOT NULL,
+                unread_count INTEGER NOT NULL,
+                summary TEXT,
+                last_timestamp INTEGER NOT NULL,
+                last_msg_type INTEGER NOT NULL,
+                last_msg_sender TEXT,
+                last_sender_display_name TEXT
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO SessionTable (
+                username, unread_count, summary, last_timestamp,
+                last_msg_type, last_msg_sender, last_sender_display_name
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                ("synthetic_casey", 1, "Quarterly review is ready", 1735689720, 1, "synthetic_casey", "Casey"),
+                (
+                    "synthetic_project@chatroom",
+                    0,
+                    "synthetic_morgan:\nDraft approved",
+                    1735689840,
+                    1,
+                    "synthetic_morgan",
+                    "Morgan",
+                ),
+            ),
+        )
+
+
+def create_message_database(path: Path) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE Name2Id (user_name TEXT NOT NULL)")
+        connection.executemany(
+            "INSERT INTO Name2Id (rowid, user_name) VALUES (?, ?)",
+            ((3, "synthetic_casey"), (5, "synthetic_morgan")),
+        )
+
+        for username in ("synthetic_casey", "synthetic_project@chatroom"):
+            table = message_table(username)
+            connection.execute(
+                f"""
+                CREATE TABLE [{table}] (
+                    local_id INTEGER PRIMARY KEY,
+                    server_id INTEGER,
+                    local_type INTEGER NOT NULL,
+                    create_time INTEGER NOT NULL,
+                    real_sender_id INTEGER,
+                    message_content TEXT,
+                    compress_content BLOB,
+                    WCDB_CT_message_content INTEGER
+                )
+                """
+            )
+
+        direct_table = message_table("synthetic_casey")
+        connection.executemany(
+            f"""
+            INSERT INTO [{direct_table}] (
+                local_id, server_id, local_type, create_time,
+                real_sender_id, message_content, compress_content,
+                WCDB_CT_message_content
+            ) VALUES (?, ?, ?, ?, ?, ?, NULL, 0)
+            """,
+            (
+                (1, 101, 1, 1735689600, 3, "Quarterly review starts Monday",),
+                (2, 102, 1, 1735689720, 3, "Quarterly review is ready",),
+            ),
+        )
+
+        group_table = message_table("synthetic_project@chatroom")
+        connection.executemany(
+            f"""
+            INSERT INTO [{group_table}] (
+                local_id, server_id, local_type, create_time,
+                real_sender_id, message_content, compress_content,
+                WCDB_CT_message_content
+            ) VALUES (?, ?, ?, ?, ?, ?, NULL, 0)
+            """,
+            (
+                (3, 103, 1, 1735689780, 5, "synthetic_morgan:\nDraft is ready",),
+                (4, 104, 3, 1735689840, 5, "<synthetic-image-payload>must-not-leak</synthetic-image-payload>",),
+            ),
+        )
+
+
+def build(output: Path) -> None:
+    if output.exists() and any(output.iterdir()):
+        raise ValueError("output directory must be empty")
+    contact_dir = output / "contact"
+    session_dir = output / "session"
+    message_dir = output / "message"
+    contact_dir.mkdir(parents=True, exist_ok=True)
+    session_dir.mkdir(parents=True, exist_ok=True)
+    message_dir.mkdir(parents=True, exist_ok=True)
+    create_contact_database(contact_dir / "contact.db")
+    create_session_database(session_dir / "session.db")
+    create_message_database(message_dir / "message_0.db")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    build(args.output.resolve())
+    print("Synthetic Vault created.")
+
+
+if __name__ == "__main__":
+    main()

--- a/yichen-wechat-windows-readonly/tests/test_windows_readonly_adapter.py
+++ b/yichen-wechat-windows-readonly/tests/test_windows_readonly_adapter.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import closing
+from pathlib import Path
+from unittest import mock
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_ROOT / "scripts" / "windows_readonly_adapter.py"
+FIXTURE_DIR = SKILL_ROOT / "tests" / "fixtures"
+sys.path.insert(0, str(SKILL_ROOT / "scripts"))
+sys.path.insert(0, str(FIXTURE_DIR))
+adapter = importlib.import_module("windows_readonly_adapter")
+fixture_builder = importlib.import_module("build_synthetic_vault")
+
+
+class AdapterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="readonly-adapter-tests-")
+        self.root = Path(self.temporary.name)
+        self.vault = self.root / "vault"
+        fixture_builder.build(self.vault)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_cli(
+        self,
+        *arguments: str,
+        consent: bool = False,
+        root: Path | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], dict]:
+        selected_root = root or self.vault
+        command = [sys.executable, str(SCRIPT), "--vault-root", str(selected_root)]
+        if consent:
+            command.append("--allow-private-content")
+        command.extend(arguments)
+        completed = subprocess.run(command, capture_output=True, text=True, timeout=20, check=False)
+        payload = json.loads(completed.stdout)
+        combined = completed.stdout + completed.stderr
+        self.assertNotIn(str(selected_root), combined)
+        return completed, payload
+
+    def contact_id(self, display_name: str) -> str:
+        completed, payload = self.run_cli("contacts", consent=True)
+        self.assertEqual(0, completed.returncode)
+        return next(
+            item["contact_id"]
+            for item in payload["result"]["contacts"]
+            if item["display_name"] == display_name
+        )
+
+    def test_vault_root_is_required_and_must_be_absolute(self) -> None:
+        missing = subprocess.run(
+            [sys.executable, str(SCRIPT), "status"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        self.assertEqual(2, missing.returncode)
+        relative = subprocess.run(
+            [sys.executable, str(SCRIPT), "--vault-root", "relative-vault", "status"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        self.assertEqual(3, relative.returncode)
+        self.assertEqual("invalid_vault_root", json.loads(relative.stdout)["error"]["code"])
+
+    def test_status_is_metadata_only_and_redacted(self) -> None:
+        completed, payload = self.run_cli("status")
+        self.assertEqual(0, completed.returncode)
+        result = payload["result"]
+        self.assertTrue(result["metadata_only"])
+        self.assertTrue(result["contacts"]["healthy"])
+        self.assertTrue(result["sessions"]["healthy"])
+        self.assertEqual(1, result["messages"]["healthy_count"])
+        output = completed.stdout
+        self.assertNotIn("synthetic_casey", output)
+        self.assertNotIn("Quarterly review", output)
+
+    def test_every_content_command_requires_current_invocation_consent(self) -> None:
+        commands = (
+            ("contacts",),
+            ("sessions",),
+            ("history", "Casey"),
+            ("search", "review"),
+            ("stats", "Casey"),
+        )
+        for command in commands:
+            with self.subTest(command=command[0]):
+                completed, payload = self.run_cli(*command)
+                self.assertEqual(3, completed.returncode)
+                self.assertEqual("consent_required", payload["error"]["code"])
+
+    def test_contacts_use_opaque_ids_and_ambiguous_names_fail(self) -> None:
+        completed, payload = self.run_cli("contacts", consent=True)
+        self.assertEqual(0, completed.returncode)
+        self.assertEqual(5, payload["result"]["count"])
+        self.assertTrue(all(item["contact_id"].startswith("contact-") for item in payload["result"]["contacts"]))
+        self.assertNotIn("synthetic_", completed.stdout)
+
+        ambiguous, error = self.run_cli("history", "Alex", consent=True)
+        self.assertEqual(3, ambiguous.returncode)
+        self.assertEqual("ambiguous_contact", error["error"]["code"])
+        self.assertEqual(2, len(error["error"]["details"]["candidates"]))
+        self.assertNotIn("synthetic_alex", ambiguous.stdout)
+
+    def test_sessions_history_search_and_stats_are_read_only_and_redacted(self) -> None:
+        sessions, sessions_payload = self.run_cli("sessions", consent=True)
+        self.assertEqual(0, sessions.returncode)
+        self.assertEqual(2, sessions_payload["result"]["count"])
+        self.assertNotIn("synthetic_", sessions.stdout)
+        self.assertIn("Draft approved", sessions.stdout)
+
+        casey_id = self.contact_id("Casey")
+        history, history_payload = self.run_cli("history", casey_id, consent=True)
+        self.assertEqual(0, history.returncode)
+        self.assertEqual(2, history_payload["result"]["count"])
+        self.assertEqual(
+            ["Quarterly review starts Monday", "Quarterly review is ready"],
+            [item["content"] for item in history_payload["result"]["messages"]],
+        )
+        self.assertNotIn("synthetic_casey", history.stdout)
+
+        search, search_payload = self.run_cli("search", "review", consent=True)
+        self.assertEqual(0, search.returncode)
+        self.assertEqual(2, search_payload["result"]["count"])
+        self.assertNotIn("synthetic_casey", search.stdout)
+
+        stats, stats_payload = self.run_cli("stats", "Project Lantern", consent=True)
+        self.assertEqual(0, stats.returncode)
+        self.assertEqual(2, stats_payload["result"]["total"])
+        self.assertEqual({"image": 1, "text": 1}, stats_payload["result"]["type_breakdown"])
+        self.assertNotIn("synthetic_morgan", stats.stdout)
+
+    def test_non_text_payload_is_never_returned(self) -> None:
+        completed, payload = self.run_cli("history", "Project Lantern", consent=True)
+        self.assertEqual(0, completed.returncode)
+        messages = payload["result"]["messages"]
+        image = next(item for item in messages if item["message_type"] == "image")
+        self.assertIsNone(image["content"])
+        self.assertTrue(image["content_omitted"])
+        self.assertNotIn("must-not-leak", completed.stdout)
+
+    def test_corruption_fails_closed_without_cached_results(self) -> None:
+        first, first_payload = self.run_cli("contacts", consent=True)
+        self.assertEqual(0, first.returncode)
+        self.assertGreater(first_payload["result"]["count"], 0)
+
+        contact_db = self.vault / "contact" / "contact.db"
+        contact_db.write_bytes(b"not a sqlite database")
+        second, second_payload = self.run_cli("contacts", consent=True)
+        self.assertEqual(3, second.returncode)
+        self.assertEqual("corrupt_database", second_payload["error"]["code"])
+        self.assertNotIn("Casey", second.stdout)
+
+        status, status_payload = self.run_cli("status")
+        self.assertEqual(0, status.returncode)
+        self.assertFalse(status_payload["result"]["contacts"]["healthy"])
+
+    def test_wrong_root_and_unsupported_schema_fail_without_path_disclosure(self) -> None:
+        missing_root = self.root / "private-owner-name" / "missing-vault"
+        completed, payload = self.run_cli("status", root=missing_root)
+        self.assertEqual(3, completed.returncode)
+        self.assertEqual("invalid_vault_root", payload["error"]["code"])
+        self.assertNotIn("private-owner-name", completed.stdout + completed.stderr)
+
+        unsupported = self.root / "unsupported"
+        (unsupported / "contact").mkdir(parents=True)
+        with closing(sqlite3.connect(unsupported / "contact" / "contact.db")) as connection, connection:
+            connection.execute("CREATE TABLE unrelated (value TEXT)")
+        failed, failed_payload = self.run_cli("contacts", consent=True, root=unsupported)
+        self.assertEqual(3, failed.returncode)
+        self.assertEqual("unsupported_schema", failed_payload["error"]["code"])
+
+    def test_source_files_are_not_modified_or_given_sidecars(self) -> None:
+        contact_dir = self.vault / "contact"
+
+        def state() -> dict[str, tuple[int, int]]:
+            return {
+                item.name: (item.stat().st_size, item.stat().st_mtime_ns)
+                for item in contact_dir.iterdir()
+            }
+
+        before = state()
+        completed, _ = self.run_cli("contacts", consent=True)
+        self.assertEqual(0, completed.returncode)
+        self.assertEqual(before, state())
+
+    def test_wal_commits_are_visible_without_source_writes(self) -> None:
+        contact_db = self.vault / "contact" / "contact.db"
+        connection = sqlite3.connect(contact_db)
+        try:
+            self.assertEqual("wal", connection.execute("PRAGMA journal_mode=WAL").fetchone()[0])
+            connection.execute("PRAGMA wal_autocheckpoint=0")
+            connection.execute(
+                """
+                INSERT INTO contact (id, username, nick_name, remark, alias, description)
+                VALUES (6, 'synthetic_taylor', 'Taylor', 'Taylor', 'taylor', '')
+                """
+            )
+            connection.commit()
+            wal = Path(f"{contact_db}-wal")
+            self.assertTrue(wal.exists())
+
+            def source_state() -> dict[str, tuple[int, int]]:
+                return {
+                    item.name: (item.stat().st_size, item.stat().st_mtime_ns)
+                    for item in contact_db.parent.iterdir()
+                }
+
+            before = source_state()
+            completed, payload = self.run_cli("contacts", consent=True)
+            self.assertEqual(0, completed.returncode)
+            self.assertIn("Taylor", [item["display_name"] for item in payload["result"]["contacts"]])
+            self.assertEqual(before, source_state())
+        finally:
+            connection.close()
+
+    def test_concurrent_source_change_fails_closed(self) -> None:
+        root = adapter.resolve_vault_root(str(self.vault))
+        source = adapter._validate_database(root, Path("contact/contact.db"))
+        original_copy = adapter.shutil.copyfile
+        changed = False
+
+        def changing_copy(source_value: str | os.PathLike, destination_value: str | os.PathLike):
+            nonlocal changed
+            result = original_copy(source_value, destination_value)
+            if Path(source_value) == source and not changed:
+                changed = True
+                with source.open("ab") as handle:
+                    handle.write(b"changed-during-snapshot")
+            return result
+
+        with mock.patch.object(adapter.shutil, "copyfile", side_effect=changing_copy):
+            with self.assertRaises(adapter.AdapterError) as raised:
+                with adapter.snapshot_databases([source]):
+                    self.fail("an unstable source must not yield a snapshot")
+        self.assertEqual("source_changed", raised.exception.code)
+
+    def test_reparse_points_are_rejected(self) -> None:
+        with mock.patch.object(adapter, "_is_reparse_point", side_effect=lambda path: path == self.vault):
+            with self.assertRaises(adapter.AdapterError) as raised:
+                adapter.resolve_vault_root(str(self.vault))
+        self.assertEqual("reparse_point_rejected", raised.exception.code)
+
+    def test_implementation_uses_only_standard_library_and_no_prohibited_runtime(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".", 1)[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".", 1)[0])
+        self.assertTrue(imported.issubset(sys.stdlib_module_names))
+        lowered = source.casefold()
+        for prohibited in (
+            "frida",
+            "jackwener",
+            "wx-cli",
+            "openprocess",
+            "writeprocessmemory",
+            "virtualallocex",
+            "create_remote_thread",
+            "ctypes",
+            "win32api",
+            "psutil",
+            "requests",
+            "subprocess",
+            "socket",
+        ):
+            self.assertNotIn(prohibited, lowered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a Windows read-only adapter for an explicitly selected, already-decrypted local Vault copy
- support metadata status, sessions, contacts, history search, and chat statistics
- require per-invocation consent before returning contact or message content
- add synthetic SQLite fixtures, automated Windows tests, provenance, and dependency/license records

## Scope and safety

This is a new reduced-scope contribution from clean baseline `ca8281900412e2256e5a45f4d6995fa340af5a71`; it does not reopen or reuse PR #10.

- explicit absolute `--vault-root` only; no directory discovery
- SQLite sources are snapshotted after stability checks and opened with `mode=ro` plus `query_only`
- fail closed for invalid paths, links/reparse points, corrupt or unsupported databases, WAL problems, and concurrent source changes
- ambiguous contacts return opaque candidate IDs instead of selecting the first match
- non-text message bodies are always omitted
- no credentials, key capture, decryption, process access/control, injection, hooks, or media decoding
- no wx-cli, jackwener code, binaries, packages, forks, mirrors, or implementation details
- no automatic Codex, Hermes, or MCP configuration changes
- runtime and tests use only Python 3.11+ standard library modules

## Provenance and dependencies

- `PROVENANCE.md` records the allowed baseline/reference boundary and every added file
- `THIRD_PARTY.md` records zero runtime dependencies and commit-pinned official CI actions
- all fixtures and records are fictional and generated in temporary directories

## Verification

- **PASS** — 13/13 unit and integration tests on Windows with Python 3.11.9
- **PASS** — explicit consent, path rejection/redaction, WAL visibility, corruption, failure closure, concurrent mutation, and contact ambiguity coverage
- **PASS** — source database remains unchanged and receives no sidecars
- **PASS** — prohibited-runtime and standard-library-only checks
- **PASS** — personal path/credential/data scan
- **PASS** — `git diff --check`
- **PASS** — remote tree matches the locally tested tree

The added Windows Actions workflow repeats fixture generation, the full test suite, and whitespace checks for this PR.